### PR TITLE
Fix output order

### DIFF
--- a/WinTime/Time.cpp
+++ b/WinTime/Time.cpp
@@ -133,8 +133,8 @@ namespace WinTime
     FileTimeToSystemTime(&lpExitTimeLocal, &t_exit);
     return PTime{ toDateString(t_create),
       toDateString(t_exit),
-      toSeconds(lpUserTime),
       toSeconds(lpKernelTime),
+      toSeconds(lpUserTime),
       toSeconds(lpCreationTime, lpExitTime) };
   }
 


### PR DESCRIPTION
Kernel time and User time were accidentally swapped
https://github.com/cbielow/wintime/blob/50adb9da23d45b9b157b51a08ee63a9ef8793d4a/WinTime/Time.h#L52-L54
https://github.com/cbielow/wintime/blob/50adb9da23d45b9b157b51a08ee63a9ef8793d4a/WinTime/Time.cpp#L136-L138