### PR TITLE
Fix memory counter struct size

### DIFF
--- a/WinTime/Memory.h
+++ b/WinTime/Memory.h
@@ -64,10 +64,9 @@ namespace WinTime
   struct ClientProcessMemoryCounter
   {
     explicit ClientProcessMemoryCounter(HANDLE hProcess)
-      : data_{}
     {
-      bool res = GetProcessMemoryInfo(hProcess, &data_, sizeof(data_));
-      if (!res)
+      data_.cb = sizeof(data_);
+      if (!GetProcessMemoryInfo(hProcess, &data_, sizeof(data_)))
       {
         throw std::runtime_error("Could not get memory info!");
       }


### PR DESCRIPTION
Correctly assigns the struct size of PROCESS_MEMORY_COUNTERS instead of just zeroing
https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-process_memory_counters